### PR TITLE
Add a "user" level to permit people to use the bridge, but not enable puppeting

### DIFF
--- a/example-config.yaml
+++ b/example-config.yaml
@@ -158,6 +158,7 @@ bridge:
 
     # Permissions for using the bridge.
     # Permitted values:
+    #       user - Only allow use of the bridge and unbridge commands.
     #   relaybot - Only use the bridge via the relaybot, no access to commands.
     #       full - Full access to use the bridge via relaybot or logging in with Telegram account.
     #      admin - Full access to use the bridge and some extra administration commands.

--- a/mautrix_telegram/commands/handler.py
+++ b/mautrix_telegram/commands/handler.py
@@ -24,7 +24,7 @@ from ..util import format_duration
 command_handlers = {}
 
 
-def command_handler(needs_auth=True, management_only=False, needs_admin=False, name=None):
+def command_handler(needs_auth=True, management_only=False, needs_admin=False, works_without_relay_bot=False, name=None):
     def decorator(func):
         async def wrapper(evt):
             if management_only and not evt.is_management:
@@ -34,6 +34,8 @@ def command_handler(needs_auth=True, management_only=False, needs_admin=False, n
                 return await evt.reply("This command requires you to be logged in.")
             elif needs_admin and not evt.sender.is_admin:
                 return await evt.reply("This is command requires administrator privileges.")
+            elif not works_without_relay_bot and not evt.sender.relaybot_whitelisted:
+                return await evt.reply("This command requires you to be allowed to use the relay bot.")
             return await func(evt)
 
         command_handlers[name or func.__name__.replace("_", "-")] = wrapper

--- a/mautrix_telegram/commands/meta.py
+++ b/mautrix_telegram/commands/meta.py
@@ -32,7 +32,7 @@ def unknown_command(evt):
     return evt.reply("Unknown command. Try `$cmdprefix+sp help` for help.")
 
 
-@command_handler(needs_auth=False)
+@command_handler(needs_auth=False, works_without_relay_bot=True)
 def help(evt):
     if evt.is_management:
         management_status = ("This is a management room: prefixing commands "
@@ -84,5 +84,16 @@ def help(evt):
 **filter** <`whitelist`|`blacklist`> <_chat ID_> - Allow or disallow bridging a specific chat.  
 **filter-mode** <`whitelist`|`blacklist`>      - Change whether the bridge will allow or disallow
                                                  bridging rooms by default.
+"""
+
+    if not evt.sender.relaybot_whitelisted and evt.sender.is_user:
+        # Because the user can't do much, we'll just show them the few things they can do.
+        help = """
+#### Bridge commands
+**help**   - Show this help message.  
+**unbridge**                - Remove puppets from the current portal room and forget the portal.  
+**bridge** [_id_]           - Bridge the current Matrix room to the Telegram chat with the given
+                              ID. The ID must be the prefixed version that you get with the `/id`
+                              command of the Telegram-side bot.  
 """
     return evt.reply(management_status + help)

--- a/mautrix_telegram/commands/portal.py
+++ b/mautrix_telegram/commands/portal.py
@@ -122,7 +122,7 @@ async def delete_portal(evt: CommandEvent):
                            "bridge, use `$cmdprefix+sp unbridge` instead.")
 
 
-@command_handler(needs_auth=False)
+@command_handler(needs_auth=False, works_without_relay_bot=True)
 async def unbridge(evt: CommandEvent):
     portal, ok = await _get_portal_and_check_permission(evt, "unbridge_room")
     if not ok:
@@ -136,7 +136,7 @@ async def unbridge(evt: CommandEvent):
                            "by typing `$cmdprefix+sp confirm-unbridge`")
 
 
-@command_handler(needs_auth=False)
+@command_handler(needs_auth=False, works_without_relay_bot=True)
 async def bridge(evt: CommandEvent):
     if len(evt.args) == 0:
         return await evt.reply("**Usage:** "

--- a/mautrix_telegram/config.py
+++ b/mautrix_telegram/config.py
@@ -226,7 +226,8 @@ class Config(DictWithRecursion):
         admin = level == "admin"
         whitelisted = level == "full" or admin
         relaybot = level == "relaybot" or whitelisted
-        return relaybot, whitelisted, admin
+        user = level == "user" or whitelisted
+        return relaybot, whitelisted, admin, user
 
     def get_permissions(self, mxid):
         permissions = self["bridge.permissions"] or {}

--- a/mautrix_telegram/matrix.py
+++ b/mautrix_telegram/matrix.py
@@ -106,7 +106,7 @@ class MatrixHandler:
                     self.log.exception("Failed to join room {room}, giving up.")
                     return
 
-        if not inviter.whitelisted:
+        if not inviter.whitelisted and not inviter.is_user:
             await self.az.intent.send_notice(
                 room, text=None,
                 html="You are not whitelisted to use this bridge.<br/><br/>"
@@ -193,7 +193,7 @@ class MatrixHandler:
     async def handle_message(self, room, sender, message, event_id):
         is_command, text = self.is_command(message)
         sender = await User.get_by_mxid(sender).ensure_started()
-        if not sender.relaybot_whitelisted:
+        if not sender.relaybot_whitelisted and not sender.is_user:
             self.log.debug(f"Ignoring message \"{message}\" from {sender} to {room}:"
                            " User is not whitelisted.")
             return
@@ -204,7 +204,7 @@ class MatrixHandler:
             await portal.handle_matrix_message(sender, message, event_id)
             return
 
-        if not sender.whitelisted or message["msgtype"] != "m.text":
+        if (not sender.whitelisted and not sender.is_user) or message["msgtype"] != "m.text":
             return
 
         try:

--- a/mautrix_telegram/user.py
+++ b/mautrix_telegram/user.py
@@ -53,7 +53,8 @@ class User(AbstractUser):
 
         (self.relaybot_whitelisted,
          self.whitelisted,
-         self.is_admin) = config.get_permissions(self.mxid)
+         self.is_admin,
+         self.is_user) = config.get_permissions(self.mxid)
 
         self.by_mxid[mxid] = self
         if tgid:


### PR DESCRIPTION
This limited permission role is targeted towards people who are hosting the bridge for the public. Bridge providers may not wish to have people's login information or access to their accounts - this role prevents puppeting for a large subset of users.

Fixes https://github.com/tulir/mautrix-telegram/issues/162