### PR TITLE
Preserve the cached tuple in the Context class

### DIFF
--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -106,8 +106,8 @@ context = Context(appserv, db_session, config, loop, None, None, session_contain
 with appserv.run(config["appservice.hostname"], config["appservice.port"]) as start:
     init_db(db_session)
     init_abstract_user(context)
-    context.bot = init_bot(context)
-    context.mx = MatrixHandler(context)
+    context.set_bot(init_bot(context))
+    context.set_mx(MatrixHandler(context))
     init_formatter(context)
     init_portal(context)
     init_puppet(context)

--- a/mautrix_telegram/context.py
+++ b/mautrix_telegram/context.py
@@ -39,6 +39,14 @@ class Context:
         self.public_website = public_website  # type: PublicBridgeWebsite
         self.provisioning_api = provisioning_api  # type: ProvisioningAPI
         self.t = (self.az, self.db, self.config, self.loop, self.bot)
+    
+    def set_bot(self, bot):
+        self.bot = bot
+        self.t = (self.az, self.db, self.config, self.loop, self.bot)
+    
+    def set_mx(self, mx):
+        self.mx = mx
+        self.t = (self.az, self.db, self.config, self.loop, self.bot)
 
     def __iter__(self):
         return iter(self.t)

--- a/mautrix_telegram/matrix.py
+++ b/mautrix_telegram/matrix.py
@@ -208,7 +208,7 @@ class MatrixHandler:
             self.log.debug(f"Ignoring message \"{message}\" from {sender} to {room}:"
                            " User is not whitelisted.")
             return
-        self.log.debug("Received Matrix event \"{message}\" from {sender} in {room}")
+        self.log.debug(f"Received Matrix event \"{message}\" from {sender} in {room}")
 
         portal = Portal.get_by_mxid(room)
         if not is_command and portal and (await sender.is_logged_in() or portal.has_bot):


### PR DESCRIPTION
What was happening was the `bot` (and `mx`) properties were initially set to `None` in the context, which also cached `None` into the `t`. Later the properties were overwritten, but `t` wasn't updated, therefore `None` would always come out as a result of using `__iter__`, leading to portals not having a `bot`.

This also includes a minor f-string fix. The property setter on the `Context` is not great and can probably be made a lot better.