### PR TITLE
Add option to replace the Matrix puppet of own Telegram account with real Matrix account

### DIFF
--- a/alembic/versions/d5f7b8b4b456_add_access_token_and_custom_mxid_fields_.py
+++ b/alembic/versions/d5f7b8b4b456_add_access_token_and_custom_mxid_fields_.py
@@ -1,0 +1,26 @@
+"""Add access_token and custom_mxid fields for puppets
+
+Revision ID: d5f7b8b4b456
+Revises: 6ca3d74d51e4
+Create Date: 2018-07-20 12:09:30.277960
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "d5f7b8b4b456"
+down_revision = "6ca3d74d51e4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("puppet", sa.Column("access_token", sa.String(), nullable=True))
+    op.add_column("puppet", sa.Column("custom_mxid", sa.String(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("puppet") as batch_op:
+        batch_op.drop_column("custom_mxid")
+        batch_op.drop_column("access_token")

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -125,6 +125,9 @@ bridge:
     # Whether or not to fetch and handle Telegram updates at startup from the time the bridge was down.
     # WARNING: Probably buggy, might get stuck in infinite loop.
     catch_up: false
+    # Whether or not to use /sync to get presence, read receipts and typing notifications when using
+    # your own Matrix account as the Matrix puppet for your Telegram account.
+    sync_with_custom_puppets: true
 
     # The formats to use when sending messages to Telegram via the relay bot.
     #

--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -110,8 +110,10 @@ with appserv.run(config["appservice.hostname"], config["appservice.port"]) as st
     context.mx = MatrixHandler(context)
     init_formatter(context)
     init_portal(context)
-    init_puppet(context)
-    startup_actions = init_user(context) + [start, context.mx.init_as_bot()]
+    startup_actions = (init_puppet(context) +
+                       init_user(context) +
+                       [start,
+                        context.mx.init_as_bot()])
 
     if context.bot:
         startup_actions.append(context.bot.start())

--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -86,7 +86,8 @@ state_store = SQLStateStore(db_session)
 appserv = AppService(config["homeserver.address"], config["homeserver.domain"],
                      config["appservice.as_token"], config["appservice.hs_token"],
                      config["appservice.bot_username"], log="mau.as", loop=loop,
-                     verify_ssl=config["homeserver.verify_ssl"], state_store=state_store)
+                     verify_ssl=config["homeserver.verify_ssl"], state_store=state_store,
+                     real_user_content_key="net.maunium.telegram.puppet")
 
 public_website = None
 provisioning_api = None

--- a/mautrix_telegram/abstract_user.py
+++ b/mautrix_telegram/abstract_user.py
@@ -36,15 +36,15 @@ class AbstractUser:
     az = None
 
     def __init__(self):
-        self.puppet_whitelisted = False
-        self.whitelisted = False
-        self.relaybot_whitelisted = False
-        self.is_admin = False
-        self.client = None
-        self.tgid = None
-        self.mxid = None
-        self.is_relaybot = False
-        self.is_bot = False
+        self.puppet_whitelisted = False  # type: bool
+        self.whitelisted = False  # type: bool
+        self.relaybot_whitelisted = False  # type: bool
+        self.is_admin = False  # type: bool
+        self.client = None  # type: MautrixTelegramClient
+        self.tgid = None  # type: int
+        self.mxid = None  # type: str
+        self.is_relaybot = False  # type: bool
+        self.is_bot = False  # type: bool
 
     @property
     def connected(self):

--- a/mautrix_telegram/abstract_user.py
+++ b/mautrix_telegram/abstract_user.py
@@ -124,7 +124,7 @@ class AbstractUser:
         self.log.debug("%s connected: %s", self.mxid, self.connected)
         return self
 
-    async def ensure_started(self, even_if_no_session=False):
+    async def ensure_started(self, even_if_no_session=False) -> "AbstractUser":
         if not self.puppet_whitelisted:
             return self
         self.log.debug("ensure_started(%s, connected=%s, even_if_no_session=%s, session_count=%s)",

--- a/mautrix_telegram/abstract_user.py
+++ b/mautrix_telegram/abstract_user.py
@@ -229,9 +229,9 @@ class AbstractUser:
     async def update_status(self, update):
         puppet = pu.Puppet.get(update.user_id)
         if isinstance(update.status, UserStatusOnline):
-            await puppet.intent.set_presence("online")
+            await puppet.default_mxid_intent.set_presence("online")
         elif isinstance(update.status, UserStatusOffline):
-            await puppet.intent.set_presence("offline")
+            await puppet.default_mxid_intent.set_presence("offline")
         else:
             self.log.warning("Unexpected user status update: %s", update)
         return

--- a/mautrix_telegram/commands/auth.py
+++ b/mautrix_telegram/commands/auth.py
@@ -49,14 +49,62 @@ async def ping_bot(evt: CommandEvent):
                            "To use the bot, simply invite it to a portal room.")
 
 
+@command_handler(needs_auth=True,
+                 help_section=SECTION_AUTH,
+                 help_text="Revert your Telegram account's Matrix puppet to use the default Matrix "
+                           "account.")
+async def logout_matrix(evt: CommandEvent):
+    puppet = pu.Puppet.get(evt.sender.tgid)
+    if not puppet.is_real_user:
+        return await evt.reply("You are not logged in with your Matrix account.")
+    await puppet.switch_mxid(None, None)
+    await evt.reply("Reverted your Telegram account's Matrix puppet back to the default.")
+
+
 @command_handler(needs_auth=True, management_only=True,
                  help_section=SECTION_AUTH,
-                 help_args="<_token_>",
                  help_text="Replace your Telegram account's Matrix puppet with your own Matrix "
                            "account")
 async def login_matrix(evt: CommandEvent):
     puppet = pu.Puppet.get(evt.sender.tgid)
-    resp = puppet.switch_mxid(" ".join(evt.args), evt.sender.mxid)
+    if puppet.is_real_user:
+        return await evt.reply("You have already logged in with your Matrix account. "
+                               "Log out with `$cmdprefix+sp logout-matrix` first.")
+    allow_matrix_login = evt.config.get("bridge.allow_matrix_login", True)
+    if allow_matrix_login:
+        evt.sender.command_status = {
+            "next": enter_matrix_token,
+            "action": "Matrix login",
+        }
+    if evt.config["appservice.public.enabled"]:
+        prefix = evt.config["appservice.public.external"]
+        url = f"{prefix}/matrix-login?token={evt.public_website.make_token(evt.sender.mxid, '/matrix-login')}"
+        if allow_matrix_login:
+            return await evt.reply(
+                "This bridge instance allows you to log in inside or outside Matrix.\n\n"
+                "If you would like to log in within Matrix, please send your Matrix access token "
+                "here.\n"
+                f"If you would like to log in outside of Matrix, [click here]({url}).\n\n"
+                "Logging in outside of Matrix is recommended, because in-Matrix login would save "
+                "your access token in the message history.")
+        return await evt.reply("This bridge instance does not allow logging in inside Matrix.\n\n"
+                               f"Please visit [the login page]({url}) to log in.")
+    elif allow_matrix_login:
+        return await evt.reply(
+            "This bridge instance does not allow you to log in outside of Matrix.\n\n"
+            "Please send your Matrix access token here to log in.")
+    return await evt.reply("This bridge instance has been configured to not allow logging in.")
+
+
+async def enter_matrix_token(evt: CommandEvent):
+    evt.sender.command_status = None
+
+    puppet = pu.Puppet.get(evt.sender.tgid)
+    if puppet.is_real_user:
+        return await evt.reply("You have already logged in with your Matrix account. "
+                               "Log out with `$cmdprefix+sp logout-matrix` first.")
+
+    resp = await puppet.switch_mxid(" ".join(evt.args), evt.sender.mxid)
     if resp == 2:
         return await evt.reply("You can only log in as your own Matrix user.")
     elif resp == 1:
@@ -130,8 +178,8 @@ async def login(evt: CommandEvent):
 
     if evt.config["appservice.public.enabled"]:
         prefix = evt.config["appservice.public.external"]
-        url = f"{prefix}/login?token={evt.public_website.make_token(evt.sender.mxid)}"
-        if evt.config.get("bridge.allow_matrix_login", True):
+        url = f"{prefix}/login?token={evt.public_website.make_token(evt.sender.mxid, '/login')}"
+        if allow_matrix_login:
             return await evt.reply(
                 "This bridge instance allows you to log in inside or outside Matrix.\n\n"
                 "If you would like to log in within Matrix, please send your phone number or bot "
@@ -144,7 +192,7 @@ async def login(evt: CommandEvent):
     elif allow_matrix_login:
         return await evt.reply(
             "This bridge instance does not allow you to log in outside of Matrix.\n\n"
-            "Please send your phone number or bot aut token here to start the login process.")
+            "Please send your phone number or bot auth token here to start the login process.")
     return await evt.reply("This bridge instance has been configured to not allow logging in.")
 
 

--- a/mautrix_telegram/commands/auth.py
+++ b/mautrix_telegram/commands/auth.py
@@ -56,15 +56,11 @@ async def ping_bot(evt: CommandEvent):
                            "account")
 async def login_matrix(evt: CommandEvent):
     puppet = pu.Puppet.get(evt.sender.tgid)
-    prev_info = puppet.custom_mxid, puppet.access_token
-    puppet.custom_mxid = evt.sender.mxid
-    puppet.access_token = " ".join(evt.args)
-    puppet.refresh_intents()
-    if not await puppet.get_profile():
-        puppet.custom_mxid, puppet.access_token = prev_info
-        puppet.refresh_intents()
+    resp = puppet.switch_mxid(" ".join(evt.args), evt.sender.mxid)
+    if resp == 2:
+        return await evt.reply("You can only log in as your own Matrix user.")
+    elif resp == 1:
         return await evt.reply("Failed to verify access token.")
-    puppet.save()
     return await evt.reply(
         f"Replaced your Telegram account's Matrix puppet with {puppet.custom_mxid}.")
 

--- a/mautrix_telegram/config.py
+++ b/mautrix_telegram/config.py
@@ -191,6 +191,7 @@ class Config(DictWithRecursion):
         copy("bridge.public_portals")
         copy("bridge.native_stickers")
         copy("bridge.catch_up")
+        copy("bridge.sync_with_custom_puppets")
 
         if "bridge.message_formats.m_text" in self:
             del self["bridge.message_formats"]

--- a/mautrix_telegram/db.py
+++ b/mautrix_telegram/db.py
@@ -137,6 +137,8 @@ class Puppet(Base):
     __tablename__ = "puppet"
 
     id = Column(Integer, primary_key=True)
+    custom_mxid = Column(String, nullable=True)
+    access_token = Column(String, nullable=True)
     displayname = Column(String, nullable=True)
     displayname_source = Column(Integer, nullable=True)
     username = Column(String, nullable=True)

--- a/mautrix_telegram/db.py
+++ b/mautrix_telegram/db.py
@@ -17,14 +17,14 @@
 from sqlalchemy import (Column, UniqueConstraint, ForeignKey, ForeignKeyConstraint, Integer,
                         BigInteger, String, Boolean, Text)
 from sqlalchemy.sql import expression
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, Query
 import json
 
 from .base import Base
 
 
 class Portal(Base):
-    query = None
+    query = None  # type: Query
     __tablename__ = "portal"
 
     # Telegram chat information
@@ -42,9 +42,8 @@ class Portal(Base):
     about = Column(String, nullable=True)
     photo_id = Column(String, nullable=True)
 
-
 class Message(Base):
-    query = None
+    query = None  # type: Query
     __tablename__ = "message"
 
     mxid = Column(String)
@@ -56,7 +55,7 @@ class Message(Base):
 
 
 class UserPortal(Base):
-    query = None
+    query = None  # type: Query
     __tablename__ = "user_portal"
 
     user = Column(Integer, ForeignKey("user.tgid", onupdate="CASCADE", ondelete="CASCADE"),
@@ -70,7 +69,7 @@ class UserPortal(Base):
 
 
 class User(Base):
-    query = None
+    query = None  # type: Query
     __tablename__ = "user"
 
     mxid = Column(String, primary_key=True)
@@ -83,7 +82,7 @@ class User(Base):
 
 
 class RoomState(Base):
-    query = None
+    query = None  # type: Query
     __tablename__ = "mx_room_state"
 
     room_id = Column(String, primary_key=True)
@@ -107,7 +106,7 @@ class RoomState(Base):
 
 
 class UserProfile(Base):
-    query = None
+    query = None  # type: Query
     __tablename__ = "mx_user_profile"
 
     room_id = Column(String, primary_key=True)
@@ -125,7 +124,7 @@ class UserProfile(Base):
 
 
 class Contact(Base):
-    query = None
+    query = None  # type: Query
     __tablename__ = "contact"
 
     user = Column(Integer, ForeignKey("user.tgid"), primary_key=True)
@@ -133,7 +132,7 @@ class Contact(Base):
 
 
 class Puppet(Base):
-    query = None
+    query = None  # type: Query
     __tablename__ = "puppet"
 
     id = Column(Integer, primary_key=True)
@@ -149,14 +148,14 @@ class Puppet(Base):
 
 # Fucking Telegram not telling bots what chats they are in 3:<
 class BotChat(Base):
-    query = None
+    query = None  # type: Query
     __tablename__ = "bot_chat"
     id = Column(Integer, primary_key=True)
     type = Column(String, nullable=False)
 
 
 class TelegramFile(Base):
-    query = None
+    query = None  # type: Query
     __tablename__ = "telegram_file"
 
     id = Column(String, primary_key=True)

--- a/mautrix_telegram/matrix.py
+++ b/mautrix_telegram/matrix.py
@@ -308,7 +308,10 @@ class MatrixHandler:
             await portal.mark_read(user, event_id)
 
     async def handle_presence(self, user: str, presence: str):
-        pass
+        user = await User.get_by_mxid(user).ensure_started()
+        if not await user.is_logged_in():
+            return
+        await user.set_presence(presence == "online")
 
     async def handle_typing(self, room_id: str, now_typing: List[str]):
         portal = Portal.get_by_mxid(room_id)

--- a/mautrix_telegram/portal.py
+++ b/mautrix_telegram/portal.py
@@ -31,6 +31,8 @@ from sqlalchemy.orm.exc import FlushError
 
 from telethon.tl.functions.messages import *
 from telethon.tl.functions.channels import *
+from telethon.tl.functions.messages import ReadHistoryRequest
+from telethon.tl.functions.channels import ReadHistoryRequest as ReadChannelHistoryRequest
 from telethon.errors import *
 from telethon.tl.types import *
 from mautrix_appservice import MatrixRequestError, IntentError
@@ -651,6 +653,23 @@ class Portal:
     async def get_displayname(self, user):
         return (await self.main_intent.get_displayname(self.mxid, user.mxid)
                 or user.mxid_localpart)
+
+    def set_typing(self, user, typing=True, action=SendMessageTypingAction):
+        return user.client(
+            SetTypingRequest(self.peer, action() if typing else SendMessageCancelAction()))
+
+    async def mark_read(self, user, event_id):
+        space = self.tgid if self.peer_type == "channel" else user.tgid
+        message = DBMessage.query.filter(DBMessage.mxid == event_id,
+                                         DBMessage.mx_room == self.mxid,
+                                         DBMessage.tg_space == space).one_or_none()
+        if not message:
+            return
+        if self.peer_type == "channel":
+            await user.client(ReadChannelHistoryRequest(
+                channel=await self.get_input_entity(user), max_id=message.tgid))
+        else:
+            await user.client(ReadHistoryRequest(peer=self.peer, max_id=message.tgid))
 
     async def leave_matrix(self, user, source, event_id):
         if await user.needs_relaybot(self):

--- a/mautrix_telegram/portal.py
+++ b/mautrix_telegram/portal.py
@@ -824,7 +824,12 @@ class Portal:
             mxid=event_id))
         self.db.commit()
 
-    async def handle_matrix_message(self, sender, message, event_id):
+    async def handle_matrix_message(self, sender: u.User, message: dict, event_id: str):
+        puppet = p.Puppet.get_by_custom_mxid(sender.mxid)
+        if puppet and message.get("net.maunium.telegram.puppet", False):
+            self.log.debug("Ignoring puppet-sent message by confirmed puppet user %s", sender.mxid)
+            return
+
         logged_in = not await sender.needs_relaybot(self)
         client = sender.client if logged_in else self.bot.client
         sender_id = sender.tgid if logged_in else self.bot.tgid

--- a/mautrix_telegram/puppet.py
+++ b/mautrix_telegram/puppet.py
@@ -107,7 +107,8 @@ class Puppet:
             if mxid != self.custom_mxid:
                 return 2
             return 1
-        asyncio.ensure_future(self.sync(), loop=self.loop)
+        if config["bridge.sync_with_custom_puppets"]:
+            asyncio.ensure_future(self.sync(), loop=self.loop)
         return 0
 
     def create_sync_filter(self) -> Awaitable[str]:

--- a/mautrix_telegram/puppet.py
+++ b/mautrix_telegram/puppet.py
@@ -169,7 +169,8 @@ class Puppet:
         self.log.debug(f"Starting syncer for {custom_mxid} with sync filter {filter_id}.")
         while access_token_at_start == self.access_token:
             try:
-                sync_resp = await self.intent.client.sync(filter=filter_id, since=next_batch)
+                sync_resp = await self.intent.client.sync(filter=filter_id, since=next_batch,
+                                                          set_presence="offline")
                 errors = 0
                 if next_batch is not None:
                     presence = sync_resp.get("presence", {}).get("events", [])

--- a/mautrix_telegram/user.py
+++ b/mautrix_telegram/user.py
@@ -22,6 +22,7 @@ import re
 from telethon.tl.types import *
 from telethon.tl.types.contacts import ContactsNotModified
 from telethon.tl.functions.contacts import GetContactsRequest, SearchRequest
+from telethon.tl.functions.account import UpdateStatusRequest
 from mautrix_appservice import MatrixRequestError
 
 from .db import User as DBUser, Contact as DBContact
@@ -187,6 +188,9 @@ class User(AbstractUser):
 
     def ensure_started(self, even_if_no_session=False) -> "Awaitable[User]":
         return super().ensure_started(even_if_no_session)
+
+    def set_presence(self, online: bool = True):
+        return self.client(UpdateStatusRequest(offline=not online))
 
     async def update_info(self, info: User = None):
         info = info or await self.client.get_me()

--- a/mautrix_telegram/user.py
+++ b/mautrix_telegram/user.py
@@ -111,14 +111,14 @@ class User(AbstractUser):
 
     def new_db_instance(self):
         return DBUser(mxid=self.mxid, tgid=self.tgid, tg_username=self.username,
-                      contacts=self.db_contacts, saved_contacts=self.saved_contacts,
+                      contacts=self.db_contacts, saved_contacts=self.saved_contacts or 0,
                       portals=self.db_portals)
 
     def save(self):
         self.db_instance.tgid = self.tgid
         self.db_instance.username = self.username
         self.db_instance.contacts = self.db_contacts
-        self.db_instance.saved_contacts = self.saved_contacts
+        self.db_instance.saved_contacts = self.saved_contacts or 0
         self.db_instance.portals = self.db_portals
         self.db.commit()
 

--- a/mautrix_telegram/user.py
+++ b/mautrix_telegram/user.py
@@ -22,6 +22,7 @@ import re
 from telethon.tl.types import *
 from telethon.tl.types.contacts import ContactsNotModified
 from telethon.tl.functions.contacts import GetContactsRequest, SearchRequest
+from telethon.tl.functions.messages import SetTypingRequest
 from mautrix_appservice import MatrixRequestError
 
 from .db import User as DBUser, Contact as DBContact
@@ -202,6 +203,10 @@ class User(AbstractUser):
             self.by_tgid[self.tgid] = self
         if changed:
             self.save()
+
+    def set_typing(self, peer, typing=True, action=SendMessageTypingAction):
+        return self.client(
+            SetTypingRequest(peer, action() if typing else SendMessageCancelAction()))
 
     async def log_out(self):
         for _, portal in self.portals.items():

--- a/mautrix_telegram/user.py
+++ b/mautrix_telegram/user.py
@@ -22,7 +22,6 @@ import re
 from telethon.tl.types import *
 from telethon.tl.types.contacts import ContactsNotModified
 from telethon.tl.functions.contacts import GetContactsRequest, SearchRequest
-from telethon.tl.functions.messages import SetTypingRequest
 from mautrix_appservice import MatrixRequestError
 
 from .db import User as DBUser, Contact as DBContact
@@ -203,10 +202,6 @@ class User(AbstractUser):
             self.by_tgid[self.tgid] = self
         if changed:
             self.save()
-
-    def set_typing(self, peer, typing=True, action=SendMessageTypingAction):
-        return self.client(
-            SetTypingRequest(peer, action() if typing else SendMessageCancelAction()))
 
     async def log_out(self):
         for _, portal in self.portals.items():

--- a/mautrix_telegram/user.py
+++ b/mautrix_telegram/user.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
-from typing import Dict
+from typing import Dict, Awaitable, Optional
 import logging
 import asyncio
 import re
@@ -185,6 +185,9 @@ class User(AbstractUser):
     # endregion
     # region Telegram actions that need custom methods
 
+    def ensure_started(self, even_if_no_session=False) -> "Awaitable[User]":
+        return super().ensure_started(even_if_no_session)
+
     async def update_info(self, info: User = None):
         info = info or await self.client.get_me()
         changed = False
@@ -309,7 +312,7 @@ class User(AbstractUser):
     # region Class instance lookup
 
     @classmethod
-    def get_by_mxid(cls, mxid, create=True):
+    def get_by_mxid(cls, mxid, create=True) -> "Optional[User]":
         if not mxid:
             raise ValueError("Matrix ID can't be empty")
 
@@ -332,7 +335,7 @@ class User(AbstractUser):
         return None
 
     @classmethod
-    def get_by_tgid(cls, tgid):
+    def get_by_tgid(cls, tgid) -> "Optional[User]":
         try:
             return cls.by_tgid[tgid]
         except KeyError:
@@ -346,7 +349,7 @@ class User(AbstractUser):
         return None
 
     @classmethod
-    def find_by_username(cls, username):
+    def find_by_username(cls, username) -> "Optional[User]":
         if not username:
             return None
 

--- a/mautrix_telegram/web/provisioning/__init__.py
+++ b/mautrix_telegram/web/provisioning/__init__.py
@@ -297,6 +297,10 @@ class ProvisioningAPI(AuthAPI):
             "errcode": errcode,
         }, status=status)
 
+    def get_mx_login_response(self, status=200, state="", username="", mxid="", message="",
+                              error="", errcode=""):
+        raise NotImplementedError()
+
     def get_login_response(self, status=200, state="", username="", mxid="", message="", error="",
                            errcode="") -> web.Response:
         if username:

--- a/mautrix_telegram/web/public/__init__.py
+++ b/mautrix_telegram/web/public/__init__.py
@@ -24,6 +24,7 @@ import time
 
 from ...util import sign_token, verify_token
 from ...user import User
+from ...puppet import Puppet
 from ..common import AuthAPI
 
 
@@ -38,28 +39,35 @@ class PublicBridgeWebsite(AuthAPI):
         self.login = Template(
             pkg_resources.resource_string("mautrix_telegram", "web/public/login.html.mako"))
 
+        self.mx_login = Template(
+            pkg_resources.resource_string("mautrix_telegram", "web/public/matrix-login.html.mako"))
+
         self.app = web.Application(loop=loop)
         self.app.router.add_route("GET", "/login", self.get_login)
         self.app.router.add_route("POST", "/login", self.post_login)
+        self.app.router.add_route("GET", "/matrix-login", self.get_matrix_login)
+        self.app.router.add_route("POST", "/matrix-login", self.post_matrix_login)
         self.app.router.add_static("/", pkg_resources.resource_filename("mautrix_telegram",
                                                                         "web/public/"))
 
-    def make_token(self, mxid, expires_in=900):
+    def make_token(self, mxid, endpoint="/login", expires_in=900):
         return sign_token(self.secret_key, {
             "mxid": mxid,
+            "endpoint": endpoint,
             "expiry": int(time.time()) + expires_in,
         })
 
-    def verify_token(self, token):
+    def verify_token(self, token, endpoint="/login"):
         token = verify_token(self.secret_key, token)
-        if token and token.get("expiry", 0) > int(time.time()):
+        if token and (token.get("expiry", 0) > int(time.time()) and
+                      token.get("endpoint", None) == endpoint):
             return token.get("mxid", None)
         return None
 
     async def get_login(self, request):
         state = "bot_token" if request.rel_url.query.get("mode", "") == "bot" else "request"
 
-        mxid = self.verify_token(request.rel_url.query.get("token", None))
+        mxid = self.verify_token(request.rel_url.query.get("token", None), endpoint="/login")
         if not mxid:
             return self.get_login_response(status=401, state="invalid-token")
         user = User.get_by_mxid(mxid, create=False) if mxid else None
@@ -75,14 +83,65 @@ class PublicBridgeWebsite(AuthAPI):
 
         return self.get_login_response(mxid=user.mxid, username=user.username)
 
+    async def get_matrix_login(self, request):
+        mxid = self.verify_token(request.rel_url.query.get("token", None), endpoint="/matrix-login")
+        if not mxid:
+            return self.get_mx_login_response(status=401, state="invalid-token")
+        user = User.get_by_mxid(mxid, create=False) if mxid else None
+
+        if not user:
+            return self.get_mx_login_response(mxid=mxid)
+        elif not user.puppet_whitelisted:
+            return self.get_mx_login_response(mxid=user.mxid, error="You are not whitelisted.",
+                                              status=403)
+        await user.ensure_started()
+        if not await user.is_logged_in():
+            return self.get_mx_login_response(mxid=user.mxid, status=403,
+                                              error="You are not logged in to Telegram.")
+
+        puppet = Puppet.get(user.tgid)
+        if puppet.is_real_user:
+            return self.get_mx_login_response(state="already-logged-in", status=409)
+
+        return self.get_mx_login_response(mxid=user.mxid)
+
     def get_login_response(self, status=200, state="", username="", mxid="", message="", error="",
                            errcode=""):
         return web.Response(status=status, content_type="text/html",
                             text=self.login.render(username=username, state=state, error=error,
                                                    message=message, mxid=mxid))
 
+    def get_mx_login_response(self, status=200, state="", username="", mxid="", message="",
+                              error="", errcode=""):
+        return web.Response(status=status, content_type="text/html",
+                            text=self.mx_login.render(username=username, state=state, error=error,
+                                                      message=message, mxid=mxid))
+
+    async def post_matrix_login(self, request):
+        mxid = self.verify_token(request.rel_url.query.get("token", None), endpoint="/matrix-login")
+        if not mxid:
+            return self.get_mx_login_response(status=401, state="invalid-token")
+
+        data = await request.post()
+
+        user = await User.get_by_mxid(mxid).ensure_started()
+        if not user.puppet_whitelisted:
+            return self.get_mx_login_response(mxid=user.mxid, error="You are not whitelisted.",
+                                              status=403)
+        elif not await user.is_logged_in():
+            return self.get_mx_login_response(mxid=user.mxid, status=403,
+                                              error="You are not logged in to Telegram.")
+        mode = data.get("mode", "access_token")
+        if mode == "password":
+            return await self.post_matrix_password(user, data["value"])
+        elif mode == "access_token":
+            return await self.post_matrix_token(user, data["value"])
+        return self.get_mx_login_response(mxid=user.mxid, status=400,
+                                          error="You must provide an access token or "
+                                                "password.")
+
     async def post_login(self, request):
-        mxid = self.verify_token(request.rel_url.query.get("token", None))
+        mxid = self.verify_token(request.rel_url.query.get("token", None), endpoint="/login")
         if not mxid:
             return self.get_login_response(status=401, state="invalid-token")
 

--- a/mautrix_telegram/web/public/login.css
+++ b/mautrix_telegram/web/public/login.css
@@ -19,8 +19,8 @@ form > div {
 	display: none;
 }
 
-form[data-status="request"]  > div.status-request,
-form[data-status="code"]     > div.status-code,
+form[data-status="request"] > div.status-request,
+form[data-status="code"] > div.status-code,
 form[data-status="password"] > div.status-password {
 	display: initial;
 }
@@ -47,4 +47,53 @@ form[data-status="password"] > div.status-password {
 	border-color: #c3e6cb;
 	background-color: #d4edda;
 	color: #155724;
+}
+
+[type="checkbox"], [type="radio"] {
+	position: absolute;
+	opacity: 0;
+}
+
+[type="checkbox"] + label, [type="radio"] + label {
+	position: relative;
+	padding-left: 2.5rem;
+	cursor: pointer;
+	display: inline-block;
+}
+
+[type="checkbox"] + label:before, [type="radio"] + label:before {
+	content: '';
+	position: absolute;
+	left: 0;
+	top: 0.4rem;
+	width: 1.8rem;
+	height: 1.8rem;
+	border: 0.1rem solid #d1d1d1;
+}
+
+[type="radio"] + label:before, [type="radio"] + label:after {
+	border-radius: 50%;
+}
+
+[type="checkbox"]:checked + label:after,
+[type="radio"]:checked + label:after {
+	content: '';
+	width: 0.8rem;
+	height: 0.8rem;
+	background: #9b4dca;
+	position: absolute;
+	top: 0.9rem;
+	left: 0.5rem;
+}
+
+[type="radio"]:disabled + label:before, [type="checkbox"]:disabled + label:before {
+	background-color: #d1d1d1;
+}
+
+[type="radio"]:disabled + label, [type="checkbox"]:disabled + label {
+	color: #d1d1d1;
+}
+
+[type="radio"]:disabled:checked + label:after, [type="checkbox"]:disabled:checked + label:after {
+	background: #606c76;
 }

--- a/mautrix_telegram/web/public/login.html.mako
+++ b/mautrix_telegram/web/public/login.html.mako
@@ -18,9 +18,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 <!DOCTYPE html>
 <html>
 <head>
-	<title>Mautrix-Telegram bridge</title>
+	<title>Login - Mautrix-Telegram bridge</title>
 	<link rel="icon" type="image/png" href="favicon.png"/>
-	<meta property="og:title" content="Mautrix-Telegram bridge">
+	<meta property="og:title" content="Login - Mautrix-Telegram bridge">
 	<meta property="og:description" content="A hybrid puppeting/relaybot Matrix-Telegram bridge">
 	<meta property="og:image" content="favicon.png">
 	<meta charset="utf-8">
@@ -40,10 +40,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 		function goBack() {
 			let params = new URLSearchParams(location.search.slice(1))
-			const mxid = params.get("mxid")
+			const token = params.get("token")
 			params = new URLSearchParams()
-			if (mxid) {
-				params.set("mxid", mxid)
+			if (token) {
+				params.set("token", token)
 			}
 			location.replace(location.href.split("?")[0] + "?" + params.toString())
 		}

--- a/mautrix_telegram/web/public/matrix-login.html.mako
+++ b/mautrix_telegram/web/public/matrix-login.html.mako
@@ -1,0 +1,78 @@
+<!--
+mautrix-telegram - A Matrix-Telegram puppeting bridge
+Copyright (C) 2018 Tulir Asokan
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Matrix login - Mautrix-Telegram bridge</title>
+	<link rel="icon" type="image/png" href="favicon.png"/>
+	<meta property="og:title" content="Matrix login - Mautrix-Telegram bridge">
+	<meta property="og:description" content="A hybrid puppeting/relaybot Matrix-Telegram bridge">
+	<meta property="og:image" content="favicon.png">
+	<meta charset="utf-8">
+	<link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,700">
+	<link rel="stylesheet" href="//cdn.rawgit.com/necolas/normalize.css/master/normalize.css">
+	<link rel="stylesheet"
+		  href="//cdn.rawgit.com/milligram/milligram/master/dist/milligram.min.css">
+	<link rel="stylesheet" href="login.css"/>
+</head>
+<body>
+<main class="container">
+	% if state == "logged-in":
+		<h1>Logged in successfully!</h1>
+		<p>
+			Logged in as ${mxid}.
+			You can now close this page.
+		</p>
+	% elif state == "already-logged-in":
+		<h1>You're already logged in!</h1>
+		<p>
+			If you want to log in with another account, log out using the
+			<code>logout-matrix</code> management command first.
+		</p>
+	% elif state == "invalid-token":
+		<h1>Invalid or expired token</h1>
+		<div class="error">Please ask the bridge bot for a new login link.</div>
+	% else:
+		<h1>Log in to Matrix</h1>
+	% if error:
+		<div class="error">${error}</div>
+	% endif
+	% if message:
+		<div class="message">${message}</div>
+	% endif
+		<form method="post">
+			<fieldset>
+				<label for="mxid">Matrix ID</label>
+				<input type="text" id="mxid" name="mxid" disabled value="${mxid}"/>
+
+				<input id="access_token" type="radio" name="mode" value="access_token" checked>
+				<label for="access_token">Access token</label><br>
+				<input id="password" type="radio" name="mode" value="password">
+				<label for="password">Password</label><br>
+
+				<label for="value">Value</label>
+				<input type="text" id="value" name="value"
+					   placeholder="Enter Matrix access token or password"/>
+
+				<button type="submit">Sign in</button>
+			</fieldset>
+		</form>
+	% endif
+</main>
+</body>
+</html>

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
 
     install_requires=[
         "aiohttp>=3.0.1,<4",
-        "mautrix-appservice>=0.3.0,<0.4.0",
+        "mautrix-appservice>=0.3.1,<0.4.0",
         "SQLAlchemy>=1.2.3,<2",
         "alembic>=1.0.0,<2",
         "Markdown>=2.6.11,<3",


### PR DESCRIPTION
Fixes #19 
Fixes #21 
Fixes #129

* [x] Basic support for replacing puppets
* [x] Ignore messages from own custom puppets
* [ ] Login
  * [x] Command
  * [x] Web UI
  * [ ] Provisioning API
* [x] Presence
* [x] Typing notifications
* [x] Read receipts
* [ ] Auto-join portals (might already happen through puppet autojoins)