### PR TITLE
Add provisioning route for getting misc bridge info

### DIFF
--- a/mautrix_telegram/web/provisioning/__init__.py
+++ b/mautrix_telegram/web/provisioning/__init__.py
@@ -64,7 +64,7 @@ class ProvisioningAPI(AuthAPI):
         self.app.router.add_route("POST", f"{user_prefix}/login/send_code", self.send_code)
         self.app.router.add_route("POST", f"{user_prefix}/login/send_password", self.send_password)
 
-        self.app.router.add_route("GET", f"/bridge", self.bridge_info)
+        self.app.router.add_route("GET", "/bridge", self.bridge_info)
 
     async def get_portal_by_mxid(self, request: web.Request) -> web.Response:
         err = self.check_authorization(request)

--- a/mautrix_telegram/web/provisioning/__init__.py
+++ b/mautrix_telegram/web/provisioning/__init__.py
@@ -64,6 +64,8 @@ class ProvisioningAPI(AuthAPI):
         self.app.router.add_route("POST", f"{user_prefix}/login/send_code", self.send_code)
         self.app.router.add_route("POST", f"{user_prefix}/login/send_password", self.send_password)
 
+        self.app.router.add_route("GET", f"/bridge", self.bridge_info)
+
     async def get_portal_by_mxid(self, request: web.Request) -> web.Response:
         err = self.check_authorization(request)
         if err is not None:
@@ -358,6 +360,11 @@ class ProvisioningAPI(AuthAPI):
         if err is not None:
             return err
         await user.log_out()
+
+    async def bridge_info(self, request: web.Request) -> web.Response:
+        return web.json_response({
+            "relaybot_username": self.context.bot.username,
+        }, status=200)
 
     @staticmethod
     async def error_middleware(_, handler: Callable[[web.Request], Awaitable[web.Response]]

--- a/mautrix_telegram/web/provisioning/spec.yaml
+++ b/mautrix_telegram/web/provisioning/spec.yaml
@@ -22,6 +22,7 @@ tags:
 - name: User info
 - name: Authentication
 - name: Bridging
+- name: Misc
 
 paths:
   /bridge:
@@ -32,10 +33,10 @@ paths:
       responses:
         200:
           description: The bridge information
-          schama:
+          schema:
             type: object
             properties:
-              relay_username:
+              relaybot_username:
                 type: string
                 description: The relay bot's username on Telegram
   /portal/{room_id}:

--- a/mautrix_telegram/web/provisioning/spec.yaml
+++ b/mautrix_telegram/web/provisioning/spec.yaml
@@ -24,6 +24,20 @@ tags:
 - name: Bridging
 
 paths:
+  /bridge:
+    get:
+      operationId: get_bridge
+      summary: Get the bridge's information
+      tags: [Misc]
+      responses:
+        200:
+          description: The bridge information
+          schama:
+            type: object
+            properties:
+              relay_username:
+                type: string
+                description: The relay bot's username on Telegram
   /portal/{room_id}:
     get:
       operationId: get_portal


### PR DESCRIPTION
Currently only the relay bot's username is exposed here.