### PR TITLE
Add a room_id param to GET /portal/:chat_id

### DIFF
--- a/mautrix_telegram/portal.py
+++ b/mautrix_telegram/portal.py
@@ -193,11 +193,12 @@ class Portal:
     # endregion
     # region Permission checks
 
-    async def can_user_perform(self, user: 'u.User', event: str, default: int = 50) -> bool:
+    async def can_user_perform(self, user: 'u.User', event: str, default: int = 50, ref_room_id: str = None) -> bool:
         if user.is_admin:
             return True
         try:
-            await self.main_intent.get_power_levels(self.mxid)
+            room_id = self.mxid if self.mxid else ref_room_id
+            await self.main_intent.get_power_levels(self.mxid, room_id)
         except MatrixRequestError:
             return False
         return self.main_intent.state_store.has_power_level(

--- a/mautrix_telegram/web/provisioning/__init__.py
+++ b/mautrix_telegram/web/provisioning/__init__.py
@@ -103,8 +103,17 @@ class ProvisioningAPI(AuthAPI):
         if not portal:
             return self.get_error_response(404, "portal_not_found",
                                            "Portal to given Telegram chat not found.")
+
+        user_id = request.query.get("user_id", None)
+        room_id = None
+        if user_id is not None:
+            room_id = request.query.get("room_id", None)
+            if not room_id:
+                return self.get_error_response(400, "missing_room_id",
+                                               "No room_id supplied")
         user, _ = await self.get_user(request.query.get("user_id", None), expect_logged_in=None,
                                       require_puppeting=False)
+
         return web.json_response({
             "mxid": portal.mxid,
             "chat_id": get_peer_id(portal.peer),
@@ -113,7 +122,7 @@ class ProvisioningAPI(AuthAPI):
             "about": portal.about,
             "username": portal.username,
             "megagroup": portal.megagroup,
-            "can_unbridge": (await portal.can_user_perform(user, "unbridge")) if user else False,
+            "can_unbridge": (await portal.can_user_perform(user, "unbridge", ref_room_id=room_id)) if user else False,
         })
 
     async def connect_chat(self, request: web.Request) -> web.Response:

--- a/mautrix_telegram/web/provisioning/spec.yaml
+++ b/mautrix_telegram/web/provisioning/spec.yaml
@@ -127,6 +127,11 @@ paths:
           description: Optional Matrix user ID to check if the user has permissions to do bridging.
           required: false
           type: string
+        - name: room_id
+          in: query
+          description: The Matrix room ID to check for user permissions in. Required if user_id is supplied.
+          required: false
+          type: string
   /portal/{room_id}/connect/{chat_id}:
     post:
       operationId: connect_portal


### PR DESCRIPTION
This is required when using the user_id param so the intent knows which room it should be checking permissions in. The integration manager is responsible for figuring out which room is the best for the context.