### PR TITLE
Add telethon-session-sqlalchemy minimum version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ alembic
 commonmark
 future-fstrings
 telethon>=1.5,<1.5.4
-telethon-session-sqlalchemy
+telethon-session-sqlalchemy>=0.2.6


### PR DESCRIPTION
To overcome the problem had in issue https://github.com/tulir/mautrix-telegram/issues/275 set minimum version to 0.2.6 (by default 0.2.5 was installed on my install)