### PR TITLE
Log startup exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/
 
 .venv
+env/
 pip-selfcheck.json
 *.pyc
 __pycache__

--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -150,3 +150,6 @@ with appserv.run(config["appservice.hostname"], config["appservice.port"]) as st
             asyncio.gather(*[user.stop() for user in User.by_tgid.values()], loop=loop))
         log.debug("Clients stopped, shutting down")
         sys.exit(0)
+    except Exception as e:
+        log.exception("Unexpected error")
+        sys.exit(1)


### PR DESCRIPTION
Some errors seem to get caught where logging can't reach them, so log them explicitly. 