### PR TITLE
Use empty collections when clearing portals/contacts instead of None

### DIFF
--- a/mautrix_telegram/db/user.py
+++ b/mautrix_telegram/db/user.py
@@ -106,8 +106,8 @@ class User(Base):
 
     def delete(self) -> None:
         super().delete()
-        self.portals = None
-        self.contacts = None
+        self.portals = []
+        self.contacts = []
 
 
 class UserPortal(Base):


### PR DESCRIPTION
This avoids an error when logging out regarding "NoneType is not iterable".