### PR TITLE
Allow config key override through env var

### DIFF
--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -22,6 +22,7 @@ import logging.config
 import sys
 import copy
 import signal
+import os
 
 import sqlalchemy as sql
 
@@ -62,7 +63,7 @@ parser.add_argument("-r", "--registration", type=str, default="registration.yaml
                     metavar="<path>", help="the path to save the generated registration to")
 args = parser.parse_args()
 
-config = Config(args.config, args.registration, args.base_config)
+config = Config(args.config, args.registration, args.base_config, os.environ)
 config.load()
 config.update()
 

--- a/mautrix_telegram/config.py
+++ b/mautrix_telegram/config.py
@@ -103,12 +103,18 @@ class DictWithRecursion:
 
 
 class Config(DictWithRecursion):
-    def __init__(self, path: str, registration_path: str, base_path: str) -> None:
+    def __init__(self, path: str, registration_path: str, base_path: str,
+                 overrides: Dict[str, Any] = {}) -> None:
         super().__init__()
         self.path = path  # type: str
         self.registration_path = registration_path  # type: str
         self.base_path = base_path  # type: str
         self._registration = None  # type: Optional[Dict]
+        self._overrides = overrides  # type: Dict[str, Any]
+
+    def __getitem__(self, key: str, prefix: str = 'MAUTRIX_TELEGRAM_') -> Any:
+        env_key = prefix + key.replace('.', '_').upper()
+        return self._overrides[env_key] or super(Config, self).__getitem__(key)
 
     def load(self) -> None:
         with open(self.path, 'r') as stream:


### PR DESCRIPTION
This PR adds the possibility for the user to override configuration keys through the use of environment variables.

For instance, one could set a value for `telegram.bot_token` by defining the `MAUTRIX_TELEGRAM_TELEGRAM_BOT_TOKEN` environment variable.

This is handy for some environment such as managed Docker containers or NixOS modules, as well as for quick testing.

The proposed changed haven't been tested.

Signed-off-by: pacien <pacien.trangirard@pacien.net>