### PR TITLE
Make 2FA error message clearer

### DIFF
--- a/mautrix_telegram/web/common/auth_api.py
+++ b/mautrix_telegram/web/common/auth_api.py
@@ -167,9 +167,13 @@ class AuthAPI(abc.ABC):
                         "next": enter_password,
                         "action": "Login (password entry)",
                     }
+                message = (
+                    "Code accepted, but you have 2-factor "
+                    "authentication enabled. Please enter your password."
+                )
                 return self.get_login_response(
-                    mxid=user.mxid, state="password", status=202,
-                    message="Code accepted, but you have 2-factor authentication is enabled.")
+                    mxid=user.mxid, state="password", status=202, message=message
+                )
             return None
         except Exception:
             self.log.exception("Error sending phone code")


### PR DESCRIPTION
I tried to log in to my Telegram account which had 2FA enabled, then I received the message "Code accepted, but you have 2-factor authentication is enabled." I didn't notice that the password field had appeared, so I assumed I needed to disable 2FA.

Only after disabling 2FA did I realize what the bridge actually wanted me to do :)

I've modified the text to hopefully be clearer in this situation.