### PR TITLE
Fix mautrix-python import error.

### DIFF
--- a/mautrix_telegram/scripts/dbms_migrate/__main__.py
+++ b/mautrix_telegram/scripts/dbms_migrate/__main__.py
@@ -24,7 +24,8 @@ def log(message, end="\n"):
 
 
 def connect(to):
-    from mautrix.bridge.db import Base, RoomState, UserProfile
+    from mautrix.util.db import Base
+    from mautrix.bridge.db import RoomState, UserProfile
     from mautrix_telegram.db import (Portal, Message, UserPortal, User, Contact, Puppet, BotChat,
                                      TelegramFile)
 


### PR DESCRIPTION
Because of mautrix-python library [API Changes](https://github.com/tulir/mautrix-python/commit/04d2ae4c3d4db5f8798f4f844caafb5d00606507). Database migration script is broken.

Change `Base` class import from `mautrix.bridge.db` to `mautrix.util.db`