### PR TITLE
Do not crash in _create_matrix_room if `invites` is `None`

### DIFF
--- a/mautrix_telegram/portal/metadata.py
+++ b/mautrix_telegram/portal/metadata.py
@@ -249,6 +249,9 @@ class PortalMetadata(BasePortal, ABC):
                                   ) -> Optional[RoomID]:
         direct = self.peer_type == "user"
 
+        if invites is None:
+            invites = []
+
         if self.mxid:
             return self.mxid
 


### PR DESCRIPTION
I noticed that the bridge crashes if you use the `/portal` bot command in an otherwise unbridged Telegram Room. 

The error was: `TypeError: unsupported operand type(s) for +=: 'NoneType' and 'CommentedSeq'`

The reason is `invites += extra_invites` in line 301, which fails if `invites` is `None`, which it seems to be when called from `handle_command_portal` in `bot.py`.

This PR just sets `invites` to an empty List if it is `None`.