### PR TITLE
Fix admin detection in _can_use_commands

### DIFF
--- a/mautrix_telegram/bot.py
+++ b/mautrix_telegram/bot.py
@@ -147,7 +147,7 @@ class Bot(AbstractUser):
         if self.whitelist_group_admins:
             if isinstance(chat, PeerChannel):
                 p = await self.client(GetParticipantRequest(chat, tgid))
-                return isinstance(p, (ChannelParticipantCreator, ChannelParticipantAdmin))
+                return isinstance(p.participant, (ChannelParticipantCreator, ChannelParticipantAdmin))
             elif isinstance(chat, PeerChat):
                 chat = await self.client(GetFullChatRequest(chat.chat_id))
                 participants = chat.full_chat.participants.participants


### PR DESCRIPTION
I noticed that admins of Telegram groups can't add a portal via the relay bot. After some print-debugging I found that `_can_use_commands` does not access the `participant` property, even though the classes it checks for seem to be stored there and not in `p` directly.

Please note that this is probably a crude fix as it is literally based on inserting `print`s at various places and changing code randomly :smile: 