### PR TITLE
Add power level override to allow enabling encryption with custom PL

### DIFF
--- a/mautrix_telegram/portal/metadata.py
+++ b/mautrix_telegram/portal/metadata.py
@@ -450,7 +450,7 @@ class PortalMetadata(BasePortal, ABC):
             levels.kick = overrides.get("kick", 50)
             levels.redact = overrides.get("redact", 50)
             levels.invite = overrides.get("invite", 50 if dbr.invite_users else 0)
-            levels.events[EventType.ROOM_ENCRYPTION] = 99
+            levels.events[EventType.ROOM_ENCRYPTION] = overrides.get("encryption", 50 if self.matrix.e2ee else 99)
             levels.events[EventType.ROOM_TOMBSTONE] = 99
             levels.events[EventType.ROOM_NAME] = 50 if dbr.change_info else 0
             levels.events[EventType.ROOM_AVATAR] = 50 if dbr.change_info else 0

--- a/mautrix_telegram/portal/metadata.py
+++ b/mautrix_telegram/portal/metadata.py
@@ -450,7 +450,7 @@ class PortalMetadata(BasePortal, ABC):
             levels.kick = overrides.get("kick", 50)
             levels.redact = overrides.get("redact", 50)
             levels.invite = overrides.get("invite", 50 if dbr.invite_users else 0)
-            levels.events[EventType.ROOM_ENCRYPTION] = overrides.get("encryption", 50 if self.matrix.e2ee else 99)
+            levels.events[EventType.ROOM_ENCRYPTION] = 50 if self.matrix.e2ee else 99
             levels.events[EventType.ROOM_TOMBSTONE] = 99
             levels.events[EventType.ROOM_NAME] = 50 if dbr.change_info else 0
             levels.events[EventType.ROOM_AVATAR] = 50 if dbr.change_info else 0


### PR DESCRIPTION
Solves #471 by adding an `encryption` override to the group power levels (could also be added to user but I'm not sure that's necessary). Will default to 50 so chat moderators can enable encryption, or 99 if encryption is not enabled for this bridge (so people do not accidentally enable encryption and break their rooms).

The biggest problem is that this is not reverse compatible with old rooms, so powerlevels will still have to be set manually there, no idea how to approach that though.