### PR TITLE
fix async puppet default leave

### DIFF
--- a/mautrix_telegram/puppet.py
+++ b/mautrix_telegram/puppet.py
@@ -343,7 +343,7 @@ class Puppet(BasePuppet):
                 return True
         return False
 
-    def default_puppet_should_leave_room(self, room_id: RoomID) -> bool:
+    async def default_puppet_should_leave_room(self, room_id: RoomID) -> bool:
         portal: p.Portal = p.Portal.get_by_mxid(room_id)
         return portal and not portal.backfill_lock.locked and portal.peer_type != "user"
 


### PR DESCRIPTION
Fixes
```
Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/mautrix/bridge/custom_puppet.py", line 208, in switch_mxid
    await self._leave_rooms_with_default_user()
  File "/usr/lib/python3.8/site-packages/mautrix/bridge/custom_puppet.py", line 267, in _leave_rooms_with_default_user
    if await self.default_puppet_should_leave_room(room_id):
TypeError: object bool can't be used in 'await' expression
```

See https://github.com/tulir/mautrix-python/commit/338c1e4f4335ecfc33b155d4f18e1010943f3865