### PR TITLE
Allow changing the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM dock.mau.dev/tulir/lottieconverter:alpine-3.13
+ARG LOTTIECONVERTER=dock.mau.dev/tulir/lottieconverter:alpine-3.13
+FROM $LOTTIECONVERTER
 
 ARG TARGETARCH=amd64
 


### PR DESCRIPTION
Otherwise it is impossible to build any unsupported architecture, since it will only work for architectures which are supported by lottieconverter on dock.mau.dev