### PR TITLE
Add empty state_key to power level events

### DIFF
--- a/mautrix_telegram/portal/metadata.py
+++ b/mautrix_telegram/portal/metadata.py
@@ -368,6 +368,7 @@ class PortalMetadata(BasePortal, ABC):
 
         initial_state = [{
             "type": EventType.ROOM_POWER_LEVELS.serialize(),
+            "state_key": "",
             "content": power_levels.serialize(),
         }, {
             "type": str(StateBridge),


### PR DESCRIPTION
Fixes #640.

This change only adds an empty state_key to the power level events in `_create_matrix_room` as the Matrix spec demands it.

The change was tested with conduit, but not with Synapse because I don't have a Synapse server available.